### PR TITLE
RO config

### DIFF
--- a/GameData/Chrayol_Design_Org/Compatibility/RealismOverhaul/PSLV_RO.cfg
+++ b/GameData/Chrayol_Design_Org/Compatibility/RealismOverhaul/PSLV_RO.cfg
@@ -1,0 +1,779 @@
+// TANKS
+
+@PART[CDO_S2Tank]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+	
+
+	@title = PSLV Stage 2 Fuel Tank
+	@description = abc
+	@mass = 4.3
+	@maxTemp = 900
+	
+	%skinMaxTemp = 2000
+	%emissiveConstant = 0.6
+	%thermalMassModifier = 1.0
+	%skinMassPerArea = 4
+
+	!RESOURCE, * {}
+
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = Default
+		volume = 37000
+		basemass = -1
+	}
+}
+
+@PART[CDO_S4TankBig1]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+	
+
+	@title = PSLV Stage 4 Fuel Tank 1
+	@description = abc
+	@mass = 0.15
+	@maxTemp = 900
+	
+	%skinMaxTemp = 2000
+	%emissiveConstant = 0.6
+	%thermalMassModifier = 1.0
+	%skinMassPerArea = 4
+
+	!RESOURCE, * {}
+
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = Default
+		volume = 1870
+		basemass = -1
+	}
+}
+
+@PART[CDO_S4TankBig2]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+	
+
+	@title = PSLV Stage 4 Fuel Tank 2
+	@description = abc
+	@mass = 0.18
+	@maxTemp = 900
+	
+	%skinMaxTemp = 2000
+	%emissiveConstant = 0.6
+	%thermalMassModifier = 1.0
+	%skinMassPerArea = 4
+
+	!RESOURCE, * {}
+
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = Default
+		volume = 1870
+		basemass = -1
+	}
+}
+
+@PART[CDO_S4TankSmall1]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+	
+
+	@title = PSLV Stage 4 Small Fuel Tank 1
+	@description = abc
+	@mass = 0.1
+	@maxTemp = 900
+	
+	%skinMaxTemp = 2000
+	%emissiveConstant = 0.6
+	%thermalMassModifier = 1.0
+	%skinMassPerArea = 4
+
+	!RESOURCE, * {}
+
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = Default
+		volume = 1250
+		basemass = -1
+	}
+}
+
+@PART[CDO_S4TankSmall2]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+	
+
+	@title = PSLV Stage 4 Small Fuel Tank 2
+	@description = abc
+	@mass = 0.1
+	@maxTemp = 900
+	
+	%skinMaxTemp = 2000
+	%emissiveConstant = 0.6
+	%thermalMassModifier = 1.0
+	%skinMassPerArea = 4
+
+	!RESOURCE, * {}
+
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = Default
+		volume = 1250
+		basemass = -1
+	}
+}
+
+// ENGINES
+
+@PART[CDO_FirstStageMotor]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+
+	@title = PSLV Stage 1 Motor
+	@description = abc
+	@mass = 30.2
+	@maxTemp = 900
+	
+	%skinMaxTemp = 2000
+	%emissiveConstant = 0.6
+	%thermalMassModifier = 1.0
+	%skinMassPerArea = 4
+
+	
+	!RESOURCE[SolidFuel]
+	{
+	}
+	!MODULE[ModuleEngineIgnitor]
+	{
+	}
+
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 77280
+		type = HTPB
+		basemass = -1
+	}
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = PSLV-stage1
+		modded = false
+		CONFIG
+		{
+			name = PSLV-stage1
+			minThrust = 4846.9
+			maxThrust = 4846.9
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = HTPB
+				ratio = 1
+				DrawGauge = True
+			}
+			atmosphereCurve
+			{
+				key = 0 269
+				key = 1 237
+			}
+			curveResource = HTPB
+			thrustCurve
+			{
+            		key = 0    0.15  0    15
+            		key = 0.03 0.66  0.5  0.5
+            		key = 1    1    -0.6    0
+			}
+		}
+	}
+
+	!MODULE[ModuleEnginesFX],1 {}
+}
+
+@PART[CDO_PS2Roll]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+	
+
+	@title = PSLV Stage 2 Roll Thruster
+	@description = abc
+	@mass = 0.1
+	@maxTemp = 900
+	
+	%skinMaxTemp = 2000
+	%emissiveConstant = 0.6
+	%thermalMassModifier = 1.0
+	%skinMassPerArea = 4
+
+	@MODULE[ModuleRCSFX]
+    {
+        @thrusterPower = 0.5
+        !resourceName = DELETE
+        @resourceFlowMode = STACK_PRIORITY_SEARCH
+        PROPELLANT
+        {
+            name = Hydrazine
+            ratio = 1.0
+        }
+		@atmosphereCurve
+        {
+            @key,0 = 0 274
+            @key,1 = 1 72
+            !key,4 = DELETE
+        }
+    }
+}
+
+
+@PART[CDO_PSOM-9]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+
+	@title = PSLV 220-G Solid Rocket Booster
+	@description = abc
+	@mass = 2
+	@maxTemp = 900
+	
+	%skinMaxTemp = 2000
+	%emissiveConstant = 0.6
+	%thermalMassModifier = 1.0
+	%skinMassPerArea = 4
+
+	
+	!RESOURCE[SolidFuel]
+	{
+	}
+	!MODULE[ModuleEngineIgnitor]
+	{
+	}
+
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 5040
+		type = HTPB
+		basemass = -1
+	}
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = 220-G
+		modded = false
+		CONFIG
+		{
+			name = 220-G
+			minThrust = 510
+			maxThrust = 510
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = HTPB
+				ratio = 1
+				DrawGauge = True
+			}
+			atmosphereCurve
+			{
+				key = 0 262
+				key = 1 245
+			}
+			curveResource = HTPB
+
+			thrustCurve
+			{
+            		key = 0    0.15  0    15
+            		key = 0.03 0.66  0.5  0.5
+            		key = 1    1    -0.6    0
+			}
+		}
+	}
+}
+
+@PART[CDO_PSOM-XL]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+
+	@title = PSLV 220-XL Solid Rocket Booster
+	@description = abc
+	@mass = 2.4
+	@maxTemp = 900
+	
+	%skinMaxTemp = 2000
+	%emissiveConstant = 0.6
+	%thermalMassModifier = 1.0
+	%skinMassPerArea = 4
+
+	
+	!RESOURCE[SolidFuel]
+	{
+	}
+	!MODULE[ModuleEngineIgnitor]
+	{
+	}
+
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 6720
+		type = HTPB
+		basemass = -1
+	}
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = 220-XL
+		modded = false
+		CONFIG
+		{
+			name = 220-XL
+			minThrust = 703.5
+			maxThrust = 703.5
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = HTPB
+				ratio = 1
+				DrawGauge = True
+			}
+			atmosphereCurve
+			{
+				key = 0 262
+				key = 1 245
+			}
+			curveResource = HTPB
+
+			thrustCurve
+			{
+            		key = 0    0.15  0    15
+            		key = 0.03 0.66  0.5  0.5
+            		key = 1    1    -0.6    0
+			}
+		}
+	}
+}
+
+@PART[CDO_S3Motor]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+
+	@title = PSLV Stage 3 Motor
+	@description = abc
+	@mass = 1.1
+	@maxTemp = 900
+	
+	%skinMaxTemp = 2000
+	%emissiveConstant = 0.6
+	%thermalMassModifier = 1.0
+	%skinMassPerArea = 4
+
+	
+	!RESOURCE[SolidFuel]
+	{
+	}
+	!MODULE[ModuleEngineIgnitor]
+	{
+	}
+
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 3950
+		type = HTPB
+		basemass = -1
+	}
+
+	@MODULE[ModuleEngines*]
+	{
+		@allowShutdown = False
+		@allowRestart = True
+		%throttleLocked = true
+		@useEngineResponseTime = False
+		!engineAccelerationSpeed = DELETE
+	}
+
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = PSLV-stage3
+		modded = false
+		CONFIG
+		{
+			name = PSLV-stage3
+			minThrust = 240
+			maxThrust = 240
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = HTPB
+				ratio = 1
+				DrawGauge = True
+			}
+			atmosphereCurve
+			{
+				key = 0 293
+				key = 1 245
+			}
+		}
+	}
+}
+
+@PART[CDO_S4Engines]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+
+	@title = PSLV Stage 4 Propulsion Module
+	@description = abc
+	@mass = 0.8
+	@maxTemp = 900
+
+	%skinMaxTemp = 2000
+	%emissiveConstant = 0.6
+	%thermalMassModifier = 1.0
+	%skinMassPerArea = 4
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = PSLV-stage4
+		modded = false
+		origMass = 0.8
+		CONFIG
+		{
+			name = PSLV-stage4
+			minThrust = 14.66
+			maxThrust = 14.66
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = MMH
+				ratio = 0.5
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = MON3
+				ratio = 0.5
+			}
+			atmosphereCurve
+			{
+				key = 0 308
+				key = 1 200
+			}
+			ullage = False
+			ignitions = 5
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 2.0
+			}
+		}
+	}
+
+	!MODULE[ModuleAlternator] {}
+	!MODULE[ModuleReactionWheel] {}
+	!RESOURCE, * {}
+	%engineTypeMult = 1
+	%clusterMultiplier = 1
+
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = Fuselage
+		volume = 1
+		basemass = -1
+		TANK
+		{
+			name = ElectricCharge
+			amount = 1000
+			maxAmount = 1000
+		}
+	}
+}
+
+@PART[CDO_Vikas2]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+
+	@title = Vikas
+	@description = abc
+	@mass = 0.9
+	@maxTemp = 900
+
+	%skinMaxTemp = 2000
+	%emissiveConstant = 0.6
+	%thermalMassModifier = 1.0
+	%skinMassPerArea = 4
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = Vikas-4
+		modded = false
+		origMass = 0.9
+		CONFIG
+		{
+			name = Vikas-4
+			minThrust = 725
+			maxThrust = 725
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = UDMH
+				ratio = 0.4963
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.5037
+			}
+			atmosphereCurve
+			{
+				key = 0 296
+				key = 1 261
+			}
+			ullage = True
+			ignitions = 1
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 2.0
+			}
+		}
+		CONFIG
+		{
+			name = Vikas-4B
+			minThrust = 804.5
+			maxThrust = 804.5
+			heatProduction = 100
+            	PROPELLANT
+            	{
+                		name = UH25
+                		ratio = 0.5056
+                		DrawGauge = True
+            	}
+
+            	PROPELLANT
+            	{
+                		name = NTO
+                		ratio = 0.4944
+                		DrawGauge = False
+            	}
+
+			atmosphereCurve
+			{
+				key = 0 302
+				key = 1 261
+			}
+			ullage = True
+			ignitions = 1
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 2.0
+			}
+		}
+	}
+
+	!MODULE[ModuleAlternator]
+	{
+	}
+	!RESOURCE[ElectricCharge]
+	{
+	}
+}
+
+// MISC
+
+@PART[CDO_RetroMotor-1]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+	
+	@title = PSLV Stage 1 Retro Motor
+	@description = abc
+	@mass = 0.1
+}
+
+@PART[CDO_RetroMotor-2]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+	
+	@title = PSLV Stage 2 Retro Motor
+	@description = abc
+	@mass = 0.1
+}
+
+@PART[CDO_UllageMotor-1]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+	
+	@title = PSLV Stage 2 Ullage Motor
+	@description = abc
+	@mass = 0.15
+}
+
+
+@PART[CDO_PayloadAdaptorLong]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+	
+	@title = PSLV Long Payload Adapter
+	@description = abc
+	@mass = 0.05
+}
+
+@PART[CDO_PayloadAdaptorShort]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+	
+	@title = PSLV Short Payload Adapter
+	@description = abc
+	@mass = 0.05
+}
+
+@PART[CDO_PayloadDecoupler1]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+	
+	@title = PSLV 1m Payload Decoupler
+	@description = abc
+	@mass = 0.05
+}
+
+@PART[CDO_PSLV_Interstage]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+	
+	@title = PSLV Interstage
+	@description = abc
+	@mass = 0.25
+}
+
+@PART[CDO_S2Mount]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+	
+	@title = PSLV Vikas 2 Mount
+	@description = abc
+	@mass = 0.1
+
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 100
+		basemass = -1
+		type = Fuselage
+		TANK
+		{
+			name = Hydrazine
+			amount = 100
+			maxAmount = 100
+		}
+	}
+
+}
+
+@PART[CDO_S4DLABottom]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+	
+	@title = PSLV Stage 4 Dual Launch Adapter Base
+	@description = abc
+	@mass = 0.05
+}
+
+@PART[CDO_S4DLATop]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+	
+	@title = PSLV Stage 4 Dual Launch Adapter Cap
+	@description = abc
+	@mass = 0.05
+}
+
+@PART[CDO_S4FairingBase]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+	
+	@title = PSLV Stage 4 Fairing Base
+	@description = abc
+	@mass = 0.1
+	@fuelCrossFeed = True
+
+	@MODULE[ModuleRCSFX]
+    	{
+        	@thrusterPower = 0.1
+        	!resourceName = DELETE
+        	@resourceFlowMode = STACK_PRIORITY_SEARCH
+        	PROPELLANT
+        	{
+            	name = Hydrazine
+            	ratio = 1.0
+        	}
+			@atmosphereCurve
+        	{
+            	@key,0 = 0 274
+            	@key,1 = 1 72
+            	!key,4 = DELETE
+        	}
+    	}
+
+}
+
+@PART[CDO_S4PayloadRack]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+	
+	@title = PSLV Stage 4 Secondary Payload Rack
+	@description = abc
+	@mass = 0.05
+}
+
+@PART[CDO_S4StructuralTube]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+	
+	@title = PSLV Stage 4 Structural Extension
+	@description = abc
+	@mass = 0.05
+}


### PR DESCRIPTION
Adding some RO configs.

Issues: 
1. Couldn't figure out how to get the verniers on Stage 1 to work, so they're removed for now.
2. Since the Fairing Base part generates a procedural fairings version, there doesn't seem to be any way to make an RO config for it (which is a problem here since it has intergrated RCS for the upper stage).