### PR TITLE
Add vesselType to PSLV S4

### DIFF
--- a/GameData/Chrayol_Design_Org/Parts/PSLV/CDO_S4Engines.cfg
+++ b/GameData/Chrayol_Design_Org/Parts/PSLV/CDO_S4Engines.cfg
@@ -30,6 +30,7 @@ PART
 	breakingTorque = 150
 	maxTemp = 2000 // = 3000
 	fuelCrossFeed = True
+	vesselType = Probe
 	bulkheadProfiles = size1, srf
 	tags = dhruveey vikas 2 pike pslv
 	EFFECTS
@@ -165,7 +166,7 @@ PART
 		useGimbalResponseSpeed = true
 		gimbalTransformName = Gimbal
 		gimbalRange = 3
-	}	
+	}
 	MODULE
 	{
 		name = ModuleSurfaceFX
@@ -239,5 +240,5 @@ PART
 		optimumRange = 2500
 		packetFloor = .1
 		packetCeiling = 5
-	}	
+	}
 }


### PR DESCRIPTION
This allows the rocket to be controlled manually.

Currently:
![pslvcurrent](https://user-images.githubusercontent.com/51132322/77534322-30604300-6e77-11ea-92f6-08969b3bae64.png)

Adding vesselType:
![pslvvesseltype](https://user-images.githubusercontent.com/51132322/77534359-4110b900-6e77-11ea-9462-0bc61b101df5.png)